### PR TITLE
Add liquidtestnet support

### DIFF
--- a/liquidswap/cli.py
+++ b/liquidswap/cli.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 from liquidswap import swap
 from liquidswap.encode import encode_payload, decode_payload
 from liquidswap.connect import ConnCtx, DEFAULT_REGTEST_RPC_PORT
-from liquidswap.constants import PROPOSED_KEYS, ACCEPTED_KEYS, NETWORK_REGTEST, NETWORK_MAINNET
+from liquidswap.constants import PROPOSED_KEYS, ACCEPTED_KEYS, NETWORK_REGTEST, NETWORK_MAINNET, NETWORK_LIQUIDTESTNET
 from liquidswap.util import (
     set_logging,
     do_initial_checks,
@@ -39,17 +39,27 @@ ConnParams = namedtuple('ConnParams', ['credentials', 'network'])
 @click.option('-c', '--conf-file', default=None, type=str,
               help='Specify elements.conf file for authentication.')
 @click.option('-r', '--regtest', is_flag=True, help='Use with regtest.')
+@click.option('-t', '--testnet', is_flag=True, help='Use with liquidtestnet.')
 @click.option('-v', '--verbose', count=True,
               help='Print more information, may be used multiple times.')
 @click.version_option()
 @click.pass_context
-def cli(ctx, service_url, conf_file, regtest, verbose):
+def cli(ctx, service_url, conf_file, regtest, testnet, verbose):
     """Liquid Swap Tool Command-Line Interface
     """
 
     set_logging(verbose)
 
-    network = NETWORK_MAINNET if not regtest else NETWORK_REGTEST
+    if regtest and testnet:
+        print("Can't use regtest and testnet at the same time")
+        sys.exit(-1)
+    if regtest:
+        network = NETWORK_REGTEST
+    elif testnet:
+        network = NETWORK_LIQUIDTESTNET
+    else:
+        network = NETWORK_MAINNET
+
     credentials = {
         'elements_conf_file': conf_file,
         'service_url': service_url,

--- a/liquidswap/constants.py
+++ b/liquidswap/constants.py
@@ -7,6 +7,12 @@ IS_REPLACEABLE = True
 NETWORK_REGTEST = 0
 NETWORK_MAINNET = 1
 
+# network names used in error messages
+NETWORK_NAMES = {
+    NETWORK_REGTEST: 'regtest',
+    NETWORK_MAINNET: 'mainnet',
+}
+
 # Use a p2sh-segwit (current liquid default) confidential dummy address so that
 # fundrawtransaction allocates the right fees.
 DUMMY_ADDRESS = {

--- a/liquidswap/constants.py
+++ b/liquidswap/constants.py
@@ -4,21 +4,24 @@ ELEMENTS_MIN_VERSION = 170000
 NLOCKTIME = 0
 IS_REPLACEABLE = True
 
+NETWORK_REGTEST = 0
+NETWORK_MAINNET = 1
+
 # Use a p2sh-segwit (current liquid default) confidential dummy address so that
 # fundrawtransaction allocates the right fees.
 DUMMY_ADDRESS = {
     # regtest: wally.base58check_from_bytes(b'\x4b' + b'\x00'*20),
-    False: 'XBMEr9McFXkiLWTVqTyuNQR1CqKkMPMn6L',
+    NETWORK_REGTEST: 'XBMEr9McFXkiLWTVqTyuNQR1CqKkMPMn6L',
     # mainnet: wally.base58check_from_bytes(b'\x27' + b'\x00'*20),
-    True: 'GhBXQEdEh35AtuSNxMzRutcgYg3nkvq5Wb',
+    NETWORK_MAINNET: 'GhBXQEdEh35AtuSNxMzRutcgYg3nkvq5Wb',
 }
 # dummy_pubkey = b'\x02'*33
 DUMMY_ADDRESS_CONFIDENTIAL = {
     # regtest: wally.confidential_addr_from_addr(dummy_add, 0x04, dummy_pubkey)
-    False: 'Azpj2QQw8ZGASK99L4BVKvH2xW9jerD9QrLenKUML7sQXMqJKJyYSwp99dASLbF5aR'
+    NETWORK_REGTEST: 'Azpj2QQw8ZGASK99L4BVKvH2xW9jerD9QrLenKUML7sQXMqJKJyYSwp99dASLbF5aR'
            'qXifmnTFhVzbZn',
     # mainnet: wally.confidential_addr_from_addr(dummy_add, 0x0c, dummy_pubkey)
-    True: 'VJL5bwudesLgrLxF4SPVyxvoWrDJhBpKf9YxQgVpMzfuLDSGndbWS832vZmKoV5KhrC'
+    NETWORK_MAINNET: 'VJL5bwudesLgrLxF4SPVyxvoWrDJhBpKf9YxQgVpMzfuLDSGndbWS832vZmKoV5KhrC'
           '2RC4SKzvn2ZbE',
 }
 # FIXME: if the receiver wallet set another addresstype, then this choice may

--- a/liquidswap/constants.py
+++ b/liquidswap/constants.py
@@ -6,11 +6,13 @@ IS_REPLACEABLE = True
 
 NETWORK_REGTEST = 0
 NETWORK_MAINNET = 1
+NETWORK_LIQUIDTESTNET = 2
 
 # network names used in error messages
 NETWORK_NAMES = {
     NETWORK_REGTEST: 'regtest',
     NETWORK_MAINNET: 'mainnet',
+    NETWORK_LIQUIDTESTNET: 'liquidtestnet',
 }
 
 # Use a p2sh-segwit (current liquid default) confidential dummy address so that
@@ -20,6 +22,8 @@ DUMMY_ADDRESS = {
     NETWORK_REGTEST: 'XBMEr9McFXkiLWTVqTyuNQR1CqKkMPMn6L',
     # mainnet: wally.base58check_from_bytes(b'\x27' + b'\x00'*20),
     NETWORK_MAINNET: 'GhBXQEdEh35AtuSNxMzRutcgYg3nkvq5Wb',
+    # liquidtestnet: wally.base58check_from_bytes(b'\x13' + b'\x00'*20)
+    NETWORK_LIQUIDTESTNET: '8eRTi4fUVRoeYEeeTyL4DPAwxatvbjaxFV',
 }
 # dummy_pubkey = b'\x02'*33
 DUMMY_ADDRESS_CONFIDENTIAL = {
@@ -29,6 +33,9 @@ DUMMY_ADDRESS_CONFIDENTIAL = {
     # mainnet: wally.confidential_addr_from_addr(dummy_add, 0x0c, dummy_pubkey)
     NETWORK_MAINNET: 'VJL5bwudesLgrLxF4SPVyxvoWrDJhBpKf9YxQgVpMzfuLDSGndbWS832vZmKoV5KhrC'
           '2RC4SKzvn2ZbE',
+    # liquidtestnet: wally.confidential_addr_from_addr(liquidtestnetaddr, 0x17, dummy_pubkey)
+    NETWORK_LIQUIDTESTNET: 'vjTtt1CgaXG8rm9cdWP8J1gz87XJ935zobn22v2usaqAod3xdnQVN6SiUM5waEjmZi'
+           'BDb2xBAGGuqPRb',
 }
 # FIXME: if the receiver wallet set another addresstype, then this choice may
 #        lead to an incorrect fee estimation. In addition, for better anonimity

--- a/liquidswap/gui/app.py
+++ b/liquidswap/gui/app.py
@@ -17,7 +17,7 @@ from liquidswap.encode import encode_payload, decode_payload
 from liquidswap.asset_data import AssetsData
 from liquidswap.connect import ConnCtx, DEFAULT_REGTEST_RPC_PORT
 from liquidswap.constants import PROPOSED_KEYS, ACCEPTED_KEYS
-from liquidswap.constants import PROPOSED_KEYS, ACCEPTED_KEYS, NETWORK_REGTEST, NETWORK_MAINNET
+from liquidswap.constants import PROPOSED_KEYS, ACCEPTED_KEYS, NETWORK_REGTEST, NETWORK_MAINNET, NETWORK_LIQUIDTESTNET
 from liquidswap.exceptions import LiquidSwapError
 from liquidswap import __version__
 from liquidswap.util import (
@@ -481,15 +481,27 @@ def parse_args():
                         help='Specify Elements node URL for authentication.')
     parser.add_argument('-r', '--regtest', action='store_true',
                         help='Use with regtest.')
+    parser.add_argument('-t', '--testnet', action='store_true',
+                        help='Use with liquidtestnet.')
     parser.add_argument('-v', '--verbose', action='count',
                         help='Be more verbose, may be used multiple times.')
     args = parser.parse_args()
     set_logging(args.verbose or 0)
 
+    if args.regtest and args.testnet:
+        print("Can't use regtest and testnet at the same time")
+        sys.exit(-1)
+    if args.regtest:
+        network = NETWORK_REGTEST
+    elif args.testnet:
+        network = NETWORK_LIQUIDTESTNET
+    else:
+        network = NETWORK_MAINNET
+
     return {
         'service_url': args.service_url,
         'elements_conf_file': args.conf_file,
-        'network': NETWORK_REGTEST if args.regtest else NETWORK_MAINNET
+        'network': network
     }
 
 

--- a/liquidswap/gui/app.py
+++ b/liquidswap/gui/app.py
@@ -366,8 +366,15 @@ class LiquidSwapToolWindow(QMainWindow):
 
         self.center()
 
+        exit = False
         with ConnCtx(self.credentials, self.critical) as cc:
-            do_initial_checks(cc.connection, network)
+            try:
+                do_initial_checks(cc.connection, network)
+            except Exception as e:
+                exit = True
+                raise(e)
+        if exit:
+            sys.exit(-1)
 
         InitialWindow(parent=self)
 

--- a/liquidswap/util.py
+++ b/liquidswap/util.py
@@ -8,6 +8,7 @@ from liquidswap.constants import (
     OWN_PROPOSAL_ERROR_MSG,
     NETWORK_REGTEST,
     NETWORK_MAINNET,
+    NETWORK_NAMES,
 )
 from liquidswap.exceptions import (
     UnexpectedValueError,
@@ -107,10 +108,8 @@ def check_network(expected_network, connection):
     """
     network = get_chain_index(connection.getblockchaininfo().get('chain'))
     if network != expected_network:
-        networks = ('regtest', 'mainnet')
-        exp, found = networks if network == NETWORK_MAINNET else reversed(networks)
         msg = 'Network mismatch: tool expecting {}, node using {}.'.format(
-            exp, found)
+            NETWORK_NAMES[expected_network], NETWORK_NAMES[network])
         raise UnexpectedValueError(msg)
 
 

--- a/liquidswap/util.py
+++ b/liquidswap/util.py
@@ -8,6 +8,7 @@ from liquidswap.constants import (
     OWN_PROPOSAL_ERROR_MSG,
     NETWORK_REGTEST,
     NETWORK_MAINNET,
+    NETWORK_LIQUIDTESTNET,
     NETWORK_NAMES,
 )
 from liquidswap.exceptions import (
@@ -46,6 +47,8 @@ def sort_dict(d):
 def get_chain_index(chain):
     if chain == 'liquidv1':
         network = NETWORK_MAINNET
+    elif chain == 'liquidtestnet':
+        network = NETWORK_LIQUIDTESTNET
     else:
         network = NETWORK_REGTEST
     return network

--- a/liquidswap/util.py
+++ b/liquidswap/util.py
@@ -6,6 +6,8 @@ from liquidswap.constants import (
     ELEMENTS_MIN_VERSION,
     WALLET_MIN_VERSION,
     OWN_PROPOSAL_ERROR_MSG,
+    NETWORK_REGTEST,
+    NETWORK_MAINNET,
 )
 from liquidswap.exceptions import (
     UnexpectedValueError,
@@ -38,6 +40,14 @@ def values2btc(m, a):
 
 def sort_dict(d):
     return {k: v for k, v in sorted(d.items())}
+
+
+def get_chain_index(chain):
+    if chain == 'liquidv1':
+        network = NETWORK_MAINNET
+    else:
+        network = NETWORK_REGTEST
+    return network
 
 
 def is_mine(address, connection):
@@ -92,25 +102,24 @@ def check_wallet_unlocked(connection):
         raise LockedWalletError('Wallet locked, please unlock it to proceed')
 
 
-def check_network(expect_mainnet, connection):
+def check_network(expected_network, connection):
     """Raise error if expected network and node network mismatch
     """
-    blockchain_info = connection.getblockchaininfo()
-    is_mainnet = blockchain_info.get('chain') == 'liquidv1'
-    if is_mainnet != expect_mainnet:
+    network = get_chain_index(connection.getblockchaininfo().get('chain'))
+    if network != expected_network:
         networks = ('regtest', 'mainnet')
-        exp, found = networks if is_mainnet else reversed(networks)
+        exp, found = networks if network == NETWORK_MAINNET else reversed(networks)
         msg = 'Network mismatch: tool expecting {}, node using {}.'.format(
             exp, found)
         raise UnexpectedValueError(msg)
 
 
-def do_initial_checks(connection, expect_mainnet):
+def do_initial_checks(connection, expected_network):
     """Do initial checks
     """
     check_liquid_version(connection)
     check_wallet_version(connection)
-    check_network(expect_mainnet, connection)
+    check_network(expected_network, connection)
 
 
 def set_logging(verbose):


### PR DESCRIPTION
Add command line option and the corresponding addresses to be able to use swaps with liquidtestnet.

Fixes: https://github.com/Blockstream/liquid-swap/issues/7